### PR TITLE
Restaurant Finder filters and modals

### DIFF
--- a/food-for-thought/app/index.tsx
+++ b/food-for-thought/app/index.tsx
@@ -30,7 +30,7 @@ export default function Index() {
 
   return (
     <View style={styles.container}>
-      <Header></Header>
+      <Header />
       {/* Card for the Restaurant finder */}
         <TouchableOpacity onPress={() => router.push('/map')}>
           <Card containerStyle={styles.finderCard}>

--- a/food-for-thought/app/map.tsx
+++ b/food-for-thought/app/map.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef } from 'react';
-import { View, Text, StyleSheet, Button, Dimensions } from 'react-native';
+import { View, Text, StyleSheet, Button, Dimensions, ScrollView } from 'react-native';
 import {
   BottomSheetModal,
   BottomSheetView,
@@ -43,25 +43,27 @@ const Map = () => {
                 type='font-awesome'
                 iconStyle={styles.icon}
                 size={20} />
-                {activeFilters.length > 0 ? activeFilters.map(f => <Badge 
-                  badgeStyle={{ 
-                    ...styles.filterBackground, 
-                    backgroundColor: filterColours[f.type]?.fill ?? 'white', 
-                    borderColor: filterColours[f.type]?.border ?? 'white'}}
-                  textStyle={styles.filterText}
-                  key={`${f.type}-${f.value}`}
-                  value={
-                    <Text style={styles.filterText}>
-                      {capitaliseFirstLetter(f.value)}
-                      <Icon
-                        name='x'
-                        type='feather'
-                        iconStyle={styles.badgesCross}
-                        size={15}
-                        onPress={() => activeFilters.length > 0 
-                          ? setActiveFilters(activeFilters.filter(filter => !(filter === f))) 
-                          : null} />
-                    </Text>} />) : <Text style={{color: 'grey', fontSize: 12, paddingTop: 5}}>No filters set</Text>}
+                <ScrollView horizontal={true} showsHorizontalScrollIndicator={false} contentContainerStyle={styles.badgeScrollView}>
+                  {activeFilters.length > 0 ? activeFilters.map(f => <Badge 
+                    badgeStyle={{ 
+                      ...styles.filterBackground, 
+                      backgroundColor: filterColours[f.type]?.fill ?? 'white', 
+                      borderColor: filterColours[f.type]?.border ?? 'white'}}
+                    textStyle={styles.filterText}
+                    key={`${f.type}-${f.value}`}
+                    value={
+                      <Text style={styles.filterText}>
+                        {capitaliseFirstLetter(f.value)}
+                        <Icon
+                          name='x'
+                          type='feather'
+                          iconStyle={styles.badgesCross}
+                          size={15}
+                          onPress={() => activeFilters.length > 0 
+                            ? setActiveFilters(activeFilters.filter(filter => !(filter === f))) 
+                            : null} />
+                    </Text>} />) : <Text style={{color: 'grey', fontSize: 12, paddingTop: 5}}>No filters set</Text>} 
+                  </ScrollView>
             </View>
             <View style={{...styles.flexContainer, paddingHorizontal: 8}}>
               {filterTypes.map(f =>
@@ -152,7 +154,7 @@ const styles = StyleSheet.create({
     gap: 4,
     height: 20,
     minHeight: 30,
-    width: '100%'
+    width: '100%',
 
   },
   typesBackground: {
@@ -162,7 +164,7 @@ const styles = StyleSheet.create({
     paddingRight: 4,
     borderStyle: 'solid',
     borderColor: '#79747E',  
-    width: 85
+    width: 85,
   },
   typesText: {
     color: '#281554',
@@ -186,16 +188,20 @@ const styles = StyleSheet.create({
     color: '#DADADA',
     paddingLeft: 4,
     height: 12,
-    width: 20
+    width: 20,
   },
   card: {
     backgroundColor: '#FBF8FF',
     padding: 20,
-    borderRadius: 20
+    borderRadius: 20,
   },
   icon: {
     color:'#534072',
     paddingHorizontal: 8,
+  },
+  badgeScrollView: {
+    flexDirection: 'row',
+    gap: 4,
   },
 });
 

--- a/food-for-thought/app/map.tsx
+++ b/food-for-thought/app/map.tsx
@@ -13,8 +13,7 @@ import Header from '@/components/Header';
 
 const Map = () => {
   const [filterType, setFilterType] = useState<string | undefined>();
-  const [activeFilters, setActiveFilters] = useState<{ type: string, value: string }[]>(
-    [{ type: 'diet', value: 'halal' }, { type: 'allergen', value: 'No Nuts' }, { type: 'ingredient', value: 'salmon' }, { type: 'cuisine', value: 'spanish' }]);
+  const [activeFilters, setActiveFilters] = useState<{ type: string, value: string }[]>([]);
   const filterTypes = ['diets', 'allergens', 'ingredients', 'cuisine'];
   // ref
   const bottomSheetModalRef = useRef<BottomSheetModal>(null);
@@ -47,8 +46,8 @@ const Map = () => {
                 {activeFilters.length > 0 ? activeFilters.map(f => <Badge 
                   badgeStyle={{ 
                     ...styles.filterBackground, 
-                    backgroundColor: filterColours[f.type].fill, 
-                    borderColor: filterColours[f.type].border }}
+                    backgroundColor: filterColours[f.type]?.fill ?? 'white', 
+                    borderColor: filterColours[f.type]?.border ?? 'white'}}
                   textStyle={styles.filterText}
                   key={`${f.type}-${f.value}`}
                   value={
@@ -60,7 +59,7 @@ const Map = () => {
                         iconStyle={styles.badgesCross}
                         size={15}
                         onPress={() => console.log('hello')} />
-                    </Text>} />) : <Text style={{color: 'grey', fontSize: 12}}>No filters set</Text>}
+                    </Text>} />) : <Text style={{color: 'grey', fontSize: 12, paddingTop: 5}}>No filters set</Text>}
             </View>
             <View style={{...styles.flexContainer, paddingHorizontal: 8}}>
               {filterTypes.map(f =>
@@ -95,7 +94,11 @@ const Map = () => {
           />
         </Card>
       </View>
-      {filterType && <DietaryFilterModal filterType={filterType} setShowModal={setFilterType} />}
+      {filterType && <DietaryFilterModal 
+        filterType={filterType} 
+        currentFilters={activeFilters}
+        setShowModal={setFilterType} 
+        setActiveFilters={setActiveFilters} />}
     </BottomSheetModalProvider>
   );
 };
@@ -105,9 +108,9 @@ function capitaliseFirstLetter(string: string) {
 }
 
 const filterColours: {[key: string]: {fill: string, border: string}} = {
-  'diet': { fill: '#FFE7DC', border: '#FEBFAC' },
-  'allergen': { fill: '#F3D9FF', border: '#D59CEF' },
-  'ingredient': { fill: '#E4EDFF', border: '#A8C1F3' },
+  'diets': { fill: '#FFE7DC', border: '#FEBFAC' },
+  'allergens': { fill: '#F3D9FF', border: '#D59CEF' },
+  'ingredients': { fill: '#E4EDFF', border: '#A8C1F3' },
   'cuisine': { fill: '#E7FFE7', border: '#B1F6B1' },
   'selected': { fill: '#E8DEF8', border: '#BDB0CA' }
 }
@@ -126,7 +129,7 @@ const styles = StyleSheet.create({
   baseCard: {
     maxHeight: 200,
     width: width - 32,
-    height: 200,
+    height: 170,
     backgroundColor: "#FBF8FF",
     padding: 12,
     borderRadius: 24,

--- a/food-for-thought/app/map.tsx
+++ b/food-for-thought/app/map.tsx
@@ -108,7 +108,7 @@ const Map = () => {
   );
 };
 
-function capitaliseFirstLetter(string: string) {
+export function capitaliseFirstLetter(string: string) {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 

--- a/food-for-thought/app/map.tsx
+++ b/food-for-thought/app/map.tsx
@@ -54,7 +54,7 @@ const Map = () => {
                     key={`${f.type}-${f.value}`}
                     value={
                       <Text style={styles.filterText}>
-                        {capitaliseFirstLetter(f.value)}
+                        {`${f.type === 'allergens' ? 'No' : ''} ${capitaliseFirstLetter(f.value)}`}
                         <Icon
                           name='x'
                           type='feather'
@@ -66,20 +66,31 @@ const Map = () => {
                     </Text>} />) : <Text style={{color: 'grey', fontSize: 12, paddingTop: 5}}>No filters set</Text>} 
                   </ScrollView>
             </View>
-            <View style={{...styles.flexContainer, paddingHorizontal: 8}}>
+            <View style={{...styles.flexContainer, paddingHorizontal: 4}}>
               {filterTypes.map(f =>
                 <Badge 
+                  containerStyle={{ flex: 1 }}
                   badgeStyle={{...styles.typesBackground, 
-                    ...(filterType === f && { 
+                    width: '100%',
+                    ...((filterType === f || activeFilters.map(f => f.type).includes(f)) && { 
                       backgroundColor: filterColours['selected'].fill, 
                       borderColor: filterColours['selected'].border 
                     }), 
                   }}
-                  textStyle={styles.typesText}
-                  // value={capitaliseFirstLetter(f)}
-                  value={f.toUpperCase()}
+                  // textStyle={styles.typesText}
+                  value={<View style={styles.filterBadgeContainer}>
+                    {activeFilters.map(f => f.type).includes(f) && <Icon
+                      name='check'
+                      type='feather'
+                      iconStyle={styles.filterCheck}
+                      size={13} />}
+                    <Text style={styles.typesText}>
+                      {capitaliseFirstLetter(f)}
+                    </Text>
+                  </View>}
                   key={f}
                   onPress={() => setFilterType(f)} />)}
+                  
             </View>
             <BottomSheetModal
               ref={bottomSheetModalRef}
@@ -145,6 +156,12 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     marginBottom: 5,
   },
+  filterBadgeContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flex: 1,
+  },
   flexContainer: {
     flex: 1,
     flexDirection: 'row',
@@ -160,13 +177,20 @@ const styles = StyleSheet.create({
     paddingLeft: 4,
     paddingRight: 4,
     borderStyle: 'solid',
-    borderColor: '#79747E',  
-    width: 85,
+    borderColor: '#79747E',
+    // width: '100%',
+    // flex: 1,
   },
   typesText: {
     color: '#281554',
-    fontWeight: '500',
-    fontSize: 9,
+    fontWeight: '400',
+    fontSize: 11,
+    letterSpacing: -0.4,
+  },
+  filterCheck: {
+    color:'#534072',
+    // fontSize: 12,
+    marginRight: 5,
   },
   filterBackground: {
     backgroundColor: '#FBF8FF',
@@ -178,7 +202,7 @@ const styles = StyleSheet.create({
   filterText: {
     color: '#281554',
     fontWeight: '300',
-    fontSize: 12,
+    fontSize: 11,
     textAlign: 'center',
   },
   badgesCross: {

--- a/food-for-thought/app/map.tsx
+++ b/food-for-thought/app/map.tsx
@@ -10,6 +10,7 @@ import { Badge, Card, Icon } from "@rneui/themed";
 import { useState } from "react";
 import { DietaryFilterModal } from '@/components/DietaryFilterModal';
 import Header from '@/components/Header';
+import { capitaliseFirstLetter } from '@/utils';
 
 const Map = () => {
   const [filterType, setFilterType] = useState<string | undefined>();
@@ -110,10 +111,6 @@ const Map = () => {
   );
 };
 
-export function capitaliseFirstLetter(string: string) {
-  return string.charAt(0).toUpperCase() + string.slice(1);
-}
-
 const filterColours: {[key: string]: {fill: string, border: string}} = {
   'diets': { fill: '#FFE7DC', border: '#FEBFAC' },
   'allergens': { fill: '#F3D9FF', border: '#D59CEF' },
@@ -180,12 +177,12 @@ const styles = StyleSheet.create({
   },
   filterText: {
     color: '#281554',
-    fontWeight: '500',
-    fontSize: 10,
+    fontWeight: '300',
+    fontSize: 12,
     textAlign: 'center',
   },
   badgesCross: {
-    color: '#DADADA',
+    color: '#BCBCBC',
     paddingLeft: 4,
     height: 12,
     width: 20,

--- a/food-for-thought/app/map.tsx
+++ b/food-for-thought/app/map.tsx
@@ -1,14 +1,15 @@
 import React, { useCallback, useMemo, useRef } from 'react';
-import { View, Text, StyleSheet, Button } from 'react-native';
+import { View, Text, StyleSheet, Button, Dimensions } from 'react-native';
 import {
   BottomSheetModal,
   BottomSheetView,
   BottomSheetModalProvider,
 } from '@gorhom/bottom-sheet';
 import SearchBar from "@/components/SearchBar";
-import { Badge, Icon } from "@rneui/themed";
+import { Badge, Card, Icon } from "@rneui/themed";
 import { useState } from "react";
 import { DietaryFilterModal } from '@/components/DietaryFilterModal';
+import Header from '@/components/Header';
 
 const Map = () => {
   const [filterType, setFilterType] = useState<string | undefined>();
@@ -33,65 +34,66 @@ const Map = () => {
   return (
     <BottomSheetModalProvider>
       <View style={styles.container}>
-        <View style={{ backgroundColor: '#FBF8FF', borderRadius: 20, flex: 1, maxHeight: 200 }}>
-          <SearchBar />
-          <View style={{ flex: 1, maxHeight: 60}}>
+        <Header />
+        <Card containerStyle={styles.baseCard}>
+          <View style={{ flexDirection: 'column', rowGap: 2}}>
+            <SearchBar />
             <View style={styles.flexContainer}>
               <Icon
                 name='sliders'
                 type='font-awesome'
                 iconStyle={styles.icon}
                 size={20} />
-                {activeFilters.map(f =>
-                  <Badge 
-                    badgeStyle={{ 
-                      ...styles.filterBackground, 
-                      backgroundColor: filterColours[f.type].fill, 
-                      borderColor: filterColours[f.type].border }}
-                    textStyle={styles.filterText}
-                    key={`${f.type}-${f.value}`}
-                    value={
-                      <Text style={styles.filterText}>
-                        {capitaliseFirstLetter(f.value)}
-                        <Icon
-                          name='x'
-                          type='feather'
-                          iconStyle={styles.badgesCross}
-                          size={15}
-                          onPress={() => console.log('hello')} />
-                      </Text>} />)}
+                {activeFilters.length > 0 ? activeFilters.map(f => <Badge 
+                  badgeStyle={{ 
+                    ...styles.filterBackground, 
+                    backgroundColor: filterColours[f.type].fill, 
+                    borderColor: filterColours[f.type].border }}
+                  textStyle={styles.filterText}
+                  key={`${f.type}-${f.value}`}
+                  value={
+                    <Text style={styles.filterText}>
+                      {capitaliseFirstLetter(f.value)}
+                      <Icon
+                        name='x'
+                        type='feather'
+                        iconStyle={styles.badgesCross}
+                        size={15}
+                        onPress={() => console.log('hello')} />
+                    </Text>} />) : <Text style={{color: 'grey', fontSize: 12}}>No filters set</Text>}
             </View>
             <View style={{...styles.flexContainer, paddingHorizontal: 8}}>
               {filterTypes.map(f =>
-                  <Badge 
-                    badgeStyle={{...styles.typesBackground, 
-                      ...(filterType === f && { backgroundColor: filterColours['selected'].fill, borderColor: filterColours['selected'].border }), 
-                    }}
-                    textStyle={styles.typesText}
-                    value={capitaliseFirstLetter(f)}
-                    key={f}
-                    onPress={() => setFilterType(f)} />)}
+                <Badge 
+                  badgeStyle={{...styles.typesBackground, 
+                    ...(filterType === f && { backgroundColor: filterColours['selected'].fill, borderColor: filterColours['selected'].border }), 
+                  }}
+                  textStyle={styles.typesText}
+                  // value={capitaliseFirstLetter(f)}
+                  value={f.toUpperCase()}
+                  key={f}
+                  onPress={() => setFilterType(f)} />)}
             </View>
+            <BottomSheetModal
+              ref={bottomSheetModalRef}
+              index={1}
+              snapPoints={snapPoints}
+              onChange={handleSheetChanges}
+            >
+              <BottomSheetView style={styles.contentContainer}>
+                <Text>Awesome 🎉</Text>
+              </BottomSheetView>
+            </BottomSheetModal>
           </View>
+        </Card>
+        <Card containerStyle={styles.baseCard}>
+          <Text>Add Map viewer here</Text>
           <Button
             onPress={handlePresentModalPress}
             title="Present Modal"
             color="black"
           />
-          <BottomSheetModal
-            ref={bottomSheetModalRef}
-            index={1}
-            snapPoints={snapPoints}
-            onChange={handleSheetChanges}
-          >
-            <BottomSheetView style={styles.contentContainer}>
-              <Text>Awesome 🎉</Text>
-            </BottomSheetView>
-          </BottomSheetModal>
-        </View>
-        <View style={{ backgroundColor: '#FBF8FF', borderRadius: 20, flex: 1, maxHeight: '40%', marginTop: 10 }}>
-          <Text>Add Map viewer here</Text>
-        </View>
+        </Card>
       </View>
       {filterType && <DietaryFilterModal filterType={filterType} setShowModal={setFilterType} />}
     </BottomSheetModalProvider>
@@ -109,22 +111,41 @@ const filterColours: {[key: string]: {fill: string, border: string}} = {
   'cuisine': { fill: '#E7FFE7', border: '#B1F6B1' },
   'selected': { fill: '#E8DEF8', border: '#BDB0CA' }
 }
+const {width} = Dimensions.get('window');
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    // padding: 24,
-    justifyContent: 'center',
+    alignItems: 'center',
     backgroundColor: '#E6D7FA',
   },
   contentContainer: {
     flex: 1,
     alignItems: 'center',
   },
+  baseCard: {
+    maxHeight: 200,
+    width: width - 32,
+    height: 200,
+    backgroundColor: "#FBF8FF",
+    padding: 12,
+    borderRadius: 24,
+    marginTop: 5,
+    elevation: 4,
+    shadowOffset: {width: 0, height: 2},
+    shadowOpacity: 2,
+    shadowRadius: 4,
+    justifyContent: "space-between",
+    marginBottom: 5,
+  },
   flexContainer: {
     flex: 1,
     flexDirection: 'row',
     gap: 4,
+    height: 20,
+    minHeight: 30,
+    width: '100%'
+
   },
   typesBackground: {
     backgroundColor: '#FBF8FF',
@@ -137,9 +158,8 @@ const styles = StyleSheet.create({
   },
   typesText: {
     color: '#281554',
-    fontFamily: 'Roboto',
     fontWeight: '500',
-    fontSize: 12,
+    fontSize: 9,
   },
   filterBackground: {
     backgroundColor: '#FBF8FF',
@@ -150,9 +170,8 @@ const styles = StyleSheet.create({
   },
   filterText: {
     color: '#281554',
-    fontFamily: 'Roboto',
-    fontWeight: '400',
-    fontSize: 11,
+    fontWeight: '500',
+    fontSize: 10,
     textAlign: 'center',
   },
   badgesCross: {

--- a/food-for-thought/app/map.tsx
+++ b/food-for-thought/app/map.tsx
@@ -58,14 +58,19 @@ const Map = () => {
                         type='feather'
                         iconStyle={styles.badgesCross}
                         size={15}
-                        onPress={() => console.log('hello')} />
+                        onPress={() => activeFilters.length > 0 
+                          ? setActiveFilters(activeFilters.filter(filter => !(filter === f))) 
+                          : null} />
                     </Text>} />) : <Text style={{color: 'grey', fontSize: 12, paddingTop: 5}}>No filters set</Text>}
             </View>
             <View style={{...styles.flexContainer, paddingHorizontal: 8}}>
               {filterTypes.map(f =>
                 <Badge 
                   badgeStyle={{...styles.typesBackground, 
-                    ...(filterType === f && { backgroundColor: filterColours['selected'].fill, borderColor: filterColours['selected'].border }), 
+                    ...(filterType === f && { 
+                      backgroundColor: filterColours['selected'].fill, 
+                      borderColor: filterColours['selected'].border 
+                    }), 
                   }}
                   textStyle={styles.typesText}
                   // value={capitaliseFirstLetter(f)}

--- a/food-for-thought/components/DietaryFilterModal.tsx
+++ b/food-for-thought/components/DietaryFilterModal.tsx
@@ -1,7 +1,7 @@
 import { Button, Icon, Overlay, Avatar, ListItem, Divider, CheckBox } from "@rneui/themed";
 import { View, StyleSheet, TextInput, ScrollView } from 'react-native';
 import * as React from "react";
-import { capitaliseFirstLetter } from "@/app/map";
+import { capitaliseFirstLetter, formatTextValue } from "@/utils";
 
 export type DietaryFilterProps = {
     setShowModal: React.Dispatch<React.SetStateAction<string | undefined>>,
@@ -12,14 +12,14 @@ export type DietaryFilterProps = {
 
 export function DietaryFilterModal({ filterType, currentFilters, setActiveFilters, setShowModal, ...rest }: DietaryFilterProps) {
   const [newFilter, setNewFilter] = React.useState<string>();
-  const allergens = ['nuts', 'eggs', 'soy', 'crustaceans', 'fish',  'milk', 'peanuts', 'sesame', 'wheat', 'lupin'];
+  const allergens = ['nuts', 'eggs', 'soy', 'crustaceans', 'fish', 'milk', 'peanuts', 'sesame', 'wheat', 'lupin'];
   const diets = ['vegetarian', 'vegan', 'halal', 'gluten-free', 'keto', 'fodmap', 'lactose-free', 'low-sugar', 'pescatarian'];
-  const cuisines = ['thai', 'indian', 'italian', 'chinese', 'japanese', 'mexican', 'korean', 'french', 'greek', 'turkish', 'vietnamese'];
+  const cuisine = ['thai', 'indian', 'italian', 'chinese', 'japanese', 'mexican', 'korean', 'french', 'greek', 'turkish', 'vietnamese'];
 
 
   function addFilter(value: string) {
     if (value === null) return;
-    const formattedValue = value.trim().toLowerCase();
+    const formattedValue = formatTextValue(value);
     if (currentFilters.length > 0) {
       !(currentFilters.find(cur => (cur.type === filterType) && (cur.value === formattedValue)))
       ? setActiveFilters(currentFilters.concat([{ type: filterType, value: formattedValue }])) 
@@ -30,27 +30,39 @@ export function DietaryFilterModal({ filterType, currentFilters, setActiveFilter
     setNewFilter(undefined);
     return;
   }
+
+  function onCheckFilter(value: string) {
+    if (value === null) return;
+    const formattedValue = formatTextValue(value);
+    if(currentFilters.find(cur => (cur.type === filterType) && (cur.value === formattedValue))){
+      setActiveFilters(currentFilters.filter(filter => !((filter.type === filterType) && (filter.value === formattedValue))));
+    } else {
+      addFilter(formattedValue);
+    }
+  }
+
   return <Overlay overlayStyle={styles.modal} isVisible={true}
     onBackdropPress={() => setShowModal(undefined)}>
     <View style={styles.flexFormGroup}>
       <TextInput
         style={styles.input}
-        placeholder="Type your ingredient..."
+        placeholder={`Enter ${filterType ? (filterType + '...') : 'ingredient...'}`}
         value={newFilter}
         onChangeText={(value) => setNewFilter(value)} />
-        {filterType && <Button buttonStyle={styles.button} onPress={() => newFilter && addFilter(newFilter)}>
-        <Icon
-          name='plus'
-          type='feather'
-          iconStyle={styles.icon}
-          size={22} />
-      </Button>}
+        {filterType && 
+        <Button buttonStyle={styles.button} onPress={() => newFilter && addFilter(newFilter)}>
+          <Icon
+            name='plus'
+            type='feather'
+            iconStyle={styles.icon}
+            size={22} />
+        </Button>}
     </View>
     <Divider style={{ marginBottom: 10}} />
     {filterType === 'allergens' ? 
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
-        {allergens.map(a => (
-          <ListItem bottomDivider containerStyle={styles.listItem} key={a}>
+        {allergens.concat(currentFilters.filter(f => (f.type === 'allergens') && (!allergens.includes(f.value))).map(f => f.value) ?? []).map(a => (
+          <ListItem bottomDivider containerStyle={styles.listItem} key={`${a}-allergens`}>
             <Avatar
               size={32}
               rounded
@@ -60,72 +72,88 @@ export function DietaryFilterModal({ filterType, currentFilters, setActiveFilter
               <ListItem.Title>{capitaliseFirstLetter(a)}</ListItem.Title>  
             </ListItem.Content>
             <CheckBox
-              key={a}
-              checked={false}
-              onPress={() => null}
+              key={`${a}-allergens-checkbox`}
+              checked={currentFilters
+                ? currentFilters.find(cur => (cur.type === filterType) && (cur.value === formatTextValue(a))) ? true : false 
+                : false}
+              onPress={() => onCheckFilter(a)}
+              checkedColor="#5A428F"
+              uncheckedColor="#BCBCBC"
+              size={22} 
               containerStyle={styles.checkBoxContainer}
             />
           </ListItem>))}
       </ScrollView>
       : filterType === 'diets' ? 
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
-        {diets.map(a => (
-          <ListItem bottomDivider containerStyle={styles.listItem} key={a}>
+          {diets.concat(currentFilters.filter(f => (f.type === 'diets') && (!diets.includes(f.value))).map(f => f.value) ?? []).map(d => (
+          <ListItem bottomDivider containerStyle={styles.listItem} key={`${d}-diets`}>
             <Avatar
               size={32}
               rounded
-              title={a[0].toUpperCase()}
+              title={d[0].toUpperCase()}
               containerStyle={{ backgroundColor: "purple" }} />
             <ListItem.Content>
-              <ListItem.Title>{capitaliseFirstLetter(a)}</ListItem.Title>  
+              <ListItem.Title>{capitaliseFirstLetter(d)}</ListItem.Title>  
             </ListItem.Content>
             <CheckBox
-              key={a}
-              checked={false}
-              onPress={() => null}
+              key={`${d}-diets-checkbox`}
+              checked={currentFilters
+                ? currentFilters.find(cur => (cur.type === filterType) && (cur.value === formatTextValue(d))) ? true : false 
+                : false}
+              onPress={() => onCheckFilter(d)}
               containerStyle={styles.checkBoxContainer}
+              checkedColor="#5A428F"
+              uncheckedColor="#BCBCBC"
+              size={22} 
             />
           </ListItem>))}
       </ScrollView>
       : filterType === 'cuisine' ? 
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
-        {cuisines.map(a => (
-          <ListItem bottomDivider containerStyle={styles.listItem} key={a}>
+        {cuisine.concat(currentFilters.filter(f => (f.type === 'cuisine') && (!diets.includes(f.value))).map(f => f.value) ?? []).map(c => (
+          <ListItem bottomDivider containerStyle={styles.listItem} key={`${c}-cuisine`}>
             <Avatar
               size={32}
               rounded
-              title={a[0].toUpperCase()}
+              title={c[0].toUpperCase()}
               containerStyle={{ backgroundColor: "purple" }} />
             <ListItem.Content>
-              <ListItem.Title>{capitaliseFirstLetter(a)}</ListItem.Title>  
+              <ListItem.Title>{capitaliseFirstLetter(c)}</ListItem.Title>  
             </ListItem.Content>
             <CheckBox
-              key={a}
-              checked={false}
-              onPress={() => null}
+              key={`${c}-cuisine-checkbox`}
+              checked={currentFilters
+                ? currentFilters.find(cur => (cur.type === filterType) && (cur.value === formatTextValue(c))) ? true : false 
+                : false}
+              onPress={() => onCheckFilter(c)}
               containerStyle={styles.checkBoxContainer}
+              checkedColor="#5A428F"
+              uncheckedColor="#BCBCBC"
+              size={22} 
             />
           </ListItem>))}
       </ScrollView>
       : <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
-        {currentFilters?.map(f => <ListItem bottomDivider containerStyle={styles.listItem} key={f.value}>
-          <Avatar
-            size={32}
-            rounded
-            title={f.value[0].toUpperCase()}
-            containerStyle={{ backgroundColor: "purple" }} />
-          <ListItem.Content>
-            <ListItem.Title>{capitaliseFirstLetter(f.value)}</ListItem.Title>  
-          </ListItem.Content>
-          <Icon
-              name='x'
-              type='feather'
-              iconStyle={styles.badgesCross}
-              size={20}
-              onPress={() => currentFilters.length > 0 
-                ? setActiveFilters(currentFilters.filter(filter => !(filter === f))) 
-                : null} />
-        </ListItem>)}
+        {(currentFilters?.filter(f => f.type === 'ingredients') ?? []).map(f => 
+          <ListItem bottomDivider containerStyle={styles.listItem} key={`${f.value}-ingredients`}>
+            <Avatar
+              size={32}
+              rounded
+              title={f.value[0].toUpperCase()}
+              containerStyle={{ backgroundColor: "purple" }} />
+            <ListItem.Content>
+              <ListItem.Title>{capitaliseFirstLetter(f.value)}</ListItem.Title>  
+            </ListItem.Content>
+            <Icon
+                name='x'
+                type='feather'
+                iconStyle={styles.badgesCross}
+                size={20}
+                onPress={() => currentFilters.length > 0 
+                  ? setActiveFilters(currentFilters.filter(filter => !(filter === f))) 
+                  : null} />
+          </ListItem>)}
       </ScrollView>}
   </Overlay>
 }
@@ -145,6 +173,7 @@ const styles = StyleSheet.create({
       alignItems: 'center',
       width: '100%',
       padding: 20,
+      paddingBottom: 0,
       paddingHorizontal: 40,
       flexDirection: 'row',
       gap: 15,

--- a/food-for-thought/components/DietaryFilterModal.tsx
+++ b/food-for-thought/components/DietaryFilterModal.tsx
@@ -12,11 +12,21 @@ export type DietaryFilterProps = {
 
 export function DietaryFilterModal({ filterType, currentFilters, setActiveFilters, setShowModal, ...rest }: DietaryFilterProps) {
   const [newFilter, setNewFilter] = React.useState<string>();
-  const allergens = ['egg', 'fish', 'crustaceans', 'nuts', 'milk', 'peanut', 'sesame', 'soy', 'wheat', 'lupin'];
+  const allergens = ['nuts', 'eggs', 'soy', 'crustaceans', 'fish',  'milk', 'peanuts', 'sesame', 'wheat', 'lupin'];
+  const diets = ['vegetarian', 'vegan', 'halal', 'gluten-free', 'keto', 'fodmap', 'lactose-free', 'low-sugar', 'pescatarian'];
+  const cuisines = ['thai', 'indian', 'italian', 'chinese', 'japanese', 'mexican', 'korean', 'french', 'greek', 'turkish', 'vietnamese'];
+
 
   function addFilter(value: string) {
     if (value === null) return;
-    setActiveFilters(currentFilters ? currentFilters.concat([{ type: filterType, value: value }]) : [{ type: filterType, value: value }])
+    const formattedValue = value.trim().toLowerCase();
+    if (currentFilters.length > 0) {
+      !(currentFilters.find(cur => (cur.type === filterType) && (cur.value === formattedValue)))
+      ? setActiveFilters(currentFilters.concat([{ type: filterType, value: formattedValue }])) 
+      : null;
+    } else {
+      setActiveFilters([{ type: filterType, value: formattedValue }]);
+    }
     setNewFilter(undefined);
     return;
   }
@@ -37,47 +47,86 @@ export function DietaryFilterModal({ filterType, currentFilters, setActiveFilter
       </Button>}
     </View>
     <Divider style={{ marginBottom: 10}} />
-    {filterType === 'allergens' ? (
-        <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
-          {allergens.map(a => (
-            <ListItem bottomDivider containerStyle={styles.listItem} key={a}>
-              <Avatar
-                size={32}
-                rounded
-                title={a[0].toUpperCase()}
-                containerStyle={{ backgroundColor: "purple" }} />
-              <ListItem.Content>
-                <ListItem.Title>{capitaliseFirstLetter(a)}</ListItem.Title>  
-              </ListItem.Content>
-              <CheckBox
-                key={a}
-                checked={false}
-                onPress={() => null}
-                containerStyle={styles.checkBoxContainer}
-              />
-            </ListItem>))}
-        </ScrollView>
-      ) : (
-    <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
-      {currentFilters?.map(f => <ListItem bottomDivider containerStyle={styles.listItem} key={f.value}>
-        <Avatar
-          size={32}
-          rounded
-          title={f.value[0].toUpperCase()}
-          containerStyle={{ backgroundColor: "purple" }} />
-        <ListItem.Content>
-          <ListItem.Title>{f.value}</ListItem.Title>  
-        </ListItem.Content>
-        <Icon
-            name='x'
-            type='feather'
-            iconStyle={styles.badgesCross}
-            size={20}
-            onPress={() => currentFilters.length > 0 
-              ? setActiveFilters(currentFilters.filter(filter => !(filter === f))) 
-              : null} />
-      </ListItem>)}
-    </ScrollView>)}
+    {filterType === 'allergens' ? 
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
+        {allergens.map(a => (
+          <ListItem bottomDivider containerStyle={styles.listItem} key={a}>
+            <Avatar
+              size={32}
+              rounded
+              title={a[0].toUpperCase()}
+              containerStyle={{ backgroundColor: "purple" }} />
+            <ListItem.Content>
+              <ListItem.Title>{capitaliseFirstLetter(a)}</ListItem.Title>  
+            </ListItem.Content>
+            <CheckBox
+              key={a}
+              checked={false}
+              onPress={() => null}
+              containerStyle={styles.checkBoxContainer}
+            />
+          </ListItem>))}
+      </ScrollView>
+      : filterType === 'diets' ? 
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
+        {diets.map(a => (
+          <ListItem bottomDivider containerStyle={styles.listItem} key={a}>
+            <Avatar
+              size={32}
+              rounded
+              title={a[0].toUpperCase()}
+              containerStyle={{ backgroundColor: "purple" }} />
+            <ListItem.Content>
+              <ListItem.Title>{capitaliseFirstLetter(a)}</ListItem.Title>  
+            </ListItem.Content>
+            <CheckBox
+              key={a}
+              checked={false}
+              onPress={() => null}
+              containerStyle={styles.checkBoxContainer}
+            />
+          </ListItem>))}
+      </ScrollView>
+      : filterType === 'cuisine' ? 
+      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
+        {cuisines.map(a => (
+          <ListItem bottomDivider containerStyle={styles.listItem} key={a}>
+            <Avatar
+              size={32}
+              rounded
+              title={a[0].toUpperCase()}
+              containerStyle={{ backgroundColor: "purple" }} />
+            <ListItem.Content>
+              <ListItem.Title>{capitaliseFirstLetter(a)}</ListItem.Title>  
+            </ListItem.Content>
+            <CheckBox
+              key={a}
+              checked={false}
+              onPress={() => null}
+              containerStyle={styles.checkBoxContainer}
+            />
+          </ListItem>))}
+      </ScrollView>
+      : <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
+        {currentFilters?.map(f => <ListItem bottomDivider containerStyle={styles.listItem} key={f.value}>
+          <Avatar
+            size={32}
+            rounded
+            title={f.value[0].toUpperCase()}
+            containerStyle={{ backgroundColor: "purple" }} />
+          <ListItem.Content>
+            <ListItem.Title>{capitaliseFirstLetter(f.value)}</ListItem.Title>  
+          </ListItem.Content>
+          <Icon
+              name='x'
+              type='feather'
+              iconStyle={styles.badgesCross}
+              size={20}
+              onPress={() => currentFilters.length > 0 
+                ? setActiveFilters(currentFilters.filter(filter => !(filter === f))) 
+                : null} />
+        </ListItem>)}
+      </ScrollView>}
   </Overlay>
 }
 

--- a/food-for-thought/components/DietaryFilterModal.tsx
+++ b/food-for-thought/components/DietaryFilterModal.tsx
@@ -1,5 +1,5 @@
 import { Button, Icon, Overlay, Avatar, ListItem, Divider } from "@rneui/themed";
-import { View, Text, StyleSheet, TextInput } from 'react-native';
+import { View, StyleSheet, TextInput, ScrollView } from 'react-native';
 import * as React from "react";
 
 export type DietaryFilterProps = {
@@ -35,24 +35,27 @@ export function DietaryFilterModal({ filterType, currentFilters, setActiveFilter
       </Button>
     </View>
     <Divider style={{ marginBottom: 10}} />
-    {currentFilters?.map(f => <ListItem bottomDivider containerStyle={styles.listItem} key={f.value}>
-      <Avatar
-        size={32}
-        rounded
-        title={f.value[0].toUpperCase()}
-        containerStyle={{ backgroundColor: "purple" }} />
-      <ListItem.Content>
-        <ListItem.Title>{f.value}</ListItem.Title>  
-      </ListItem.Content>
-      <Icon
-          name='x'
-          type='feather'
-          iconStyle={styles.badgesCross}
-          size={20}
-          onPress={() => currentFilters.length > 0 
-            ? setActiveFilters(currentFilters.filter(filter => !(filter === f))) 
-            : null} />
-    </ListItem>)}
+
+    <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
+      {currentFilters?.map(f => <ListItem bottomDivider containerStyle={styles.listItem} key={f.value}>
+        <Avatar
+          size={32}
+          rounded
+          title={f.value[0].toUpperCase()}
+          containerStyle={{ backgroundColor: "purple" }} />
+        <ListItem.Content>
+          <ListItem.Title>{f.value}</ListItem.Title>  
+        </ListItem.Content>
+        <Icon
+            name='x'
+            type='feather'
+            iconStyle={styles.badgesCross}
+            size={20}
+            onPress={() => currentFilters.length > 0 
+              ? setActiveFilters(currentFilters.filter(filter => !(filter === f))) 
+              : null} />
+      </ListItem>)}
+    </ScrollView>
   </Overlay>
 }
 
@@ -64,17 +67,14 @@ const styles = StyleSheet.create({
       backgroundColor: '#FBF8FF',
       borderRadius: 20,
       width: '90%',
-      maxHeight: 210,
       padding: 15,
-      flex: 1,
     },
     flexFormGroup: {
       justifyContent: 'center',
       alignItems: 'center',
-      width: '90%',
-      paddingHorizontal: 15,
-      paddingTop: 30,
-      flex: 1,
+      width: '100%',
+      padding: 20,
+      paddingHorizontal: 40,
       flexDirection: 'row',
       gap: 15,
     },
@@ -109,5 +109,12 @@ const styles = StyleSheet.create({
     listItem: {
       width: '100%',
       backgroundColor: 'inherit',
+    },
+    scrollView: {
+      maxHeight: 270,
+      width: '100%',
+    },
+    scrollViewContent: {
+      paddingBottom: 10,
     },
   });

--- a/food-for-thought/components/DietaryFilterModal.tsx
+++ b/food-for-thought/components/DietaryFilterModal.tsx
@@ -1,6 +1,7 @@
-import { Button, Icon, Overlay, Avatar, ListItem, Divider } from "@rneui/themed";
+import { Button, Icon, Overlay, Avatar, ListItem, Divider, CheckBox } from "@rneui/themed";
 import { View, StyleSheet, TextInput, ScrollView } from 'react-native';
 import * as React from "react";
+import { capitaliseFirstLetter } from "@/app/map";
 
 export type DietaryFilterProps = {
     setShowModal: React.Dispatch<React.SetStateAction<string | undefined>>,
@@ -11,6 +12,7 @@ export type DietaryFilterProps = {
 
 export function DietaryFilterModal({ filterType, currentFilters, setActiveFilters, setShowModal, ...rest }: DietaryFilterProps) {
   const [newFilter, setNewFilter] = React.useState<string>();
+  const allergens = ['egg', 'fish', 'crustaceans', 'nuts', 'milk', 'peanut', 'sesame', 'soy', 'wheat', 'lupin'];
 
   function addFilter(value: string) {
     if (value === null) return;
@@ -26,16 +28,36 @@ export function DietaryFilterModal({ filterType, currentFilters, setActiveFilter
         placeholder="Type your ingredient..."
         value={newFilter}
         onChangeText={(value) => setNewFilter(value)} />
-        <Button buttonStyle={styles.button} onPress={() => newFilter && addFilter(newFilter)}>
+        {filterType && <Button buttonStyle={styles.button} onPress={() => newFilter && addFilter(newFilter)}>
         <Icon
           name='plus'
           type='feather'
           iconStyle={styles.icon}
           size={22} />
-      </Button>
+      </Button>}
     </View>
     <Divider style={{ marginBottom: 10}} />
-
+    {filterType === 'allergens' ? (
+        <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
+          {allergens.map(a => (
+            <ListItem bottomDivider containerStyle={styles.listItem} key={a}>
+              <Avatar
+                size={32}
+                rounded
+                title={a[0].toUpperCase()}
+                containerStyle={{ backgroundColor: "purple" }} />
+              <ListItem.Content>
+                <ListItem.Title>{capitaliseFirstLetter(a)}</ListItem.Title>  
+              </ListItem.Content>
+              <CheckBox
+                key={a}
+                checked={false}
+                onPress={() => null}
+                containerStyle={styles.checkBoxContainer}
+              />
+            </ListItem>))}
+        </ScrollView>
+      ) : (
     <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
       {currentFilters?.map(f => <ListItem bottomDivider containerStyle={styles.listItem} key={f.value}>
         <Avatar
@@ -55,7 +77,7 @@ export function DietaryFilterModal({ filterType, currentFilters, setActiveFilter
               ? setActiveFilters(currentFilters.filter(filter => !(filter === f))) 
               : null} />
       </ListItem>)}
-    </ScrollView>
+    </ScrollView>)}
   </Overlay>
 }
 
@@ -108,7 +130,7 @@ const styles = StyleSheet.create({
     },
     listItem: {
       width: '100%',
-      backgroundColor: 'inherit',
+      backgroundColor: 'inherit'
     },
     scrollView: {
       maxHeight: 270,
@@ -116,5 +138,11 @@ const styles = StyleSheet.create({
     },
     scrollViewContent: {
       paddingBottom: 10,
+    },
+    checkBoxContainer: {
+      backgroundColor: 'transparent',
+      borderWidth: 0,
+      padding: 0,
+      margin: 0,
     },
   });

--- a/food-for-thought/components/DietaryFilterModal.tsx
+++ b/food-for-thought/components/DietaryFilterModal.tsx
@@ -4,11 +4,11 @@ import * as React from "react";
 import { capitaliseFirstLetter, formatTextValue } from "@/utils";
 
 export type DietaryFilterProps = {
-    setShowModal: React.Dispatch<React.SetStateAction<string | undefined>>,
-    setActiveFilters: React.Dispatch<React.SetStateAction<{ type: string, value: string }[]>>,
-    currentFilters: { type: string, value: string }[],
-    filterType: string,
-  };
+  setShowModal: React.Dispatch<React.SetStateAction<string | undefined>>,
+  setActiveFilters: React.Dispatch<React.SetStateAction<{ type: string, value: string }[]>>,
+  currentFilters: { type: string, value: string }[],
+  filterType: string,
+};
 
 export function DietaryFilterModal({ filterType, currentFilters, setActiveFilters, setShowModal, ...rest }: DietaryFilterProps) {
   const [newFilter, setNewFilter] = React.useState<string>();
@@ -22,8 +22,8 @@ export function DietaryFilterModal({ filterType, currentFilters, setActiveFilter
     const formattedValue = formatTextValue(value);
     if (currentFilters.length > 0) {
       !(currentFilters.find(cur => (cur.type === filterType) && (cur.value === formattedValue)))
-      ? setActiveFilters(currentFilters.concat([{ type: filterType, value: formattedValue }])) 
-      : null;
+        ? setActiveFilters(currentFilters.concat([{ type: filterType, value: formattedValue }]))
+        : null;
     } else {
       setActiveFilters([{ type: filterType, value: formattedValue }]);
     }
@@ -34,7 +34,7 @@ export function DietaryFilterModal({ filterType, currentFilters, setActiveFilter
   function onCheckFilter(value: string) {
     if (value === null) return;
     const formattedValue = formatTextValue(value);
-    if(currentFilters.find(cur => (cur.type === filterType) && (cur.value === formattedValue))){
+    if (currentFilters.find(cur => (cur.type === filterType) && (cur.value === formattedValue))) {
       setActiveFilters(currentFilters.filter(filter => !((filter.type === filterType) && (filter.value === formattedValue))));
     } else {
       addFilter(formattedValue);
@@ -49,7 +49,7 @@ export function DietaryFilterModal({ filterType, currentFilters, setActiveFilter
         placeholder={`Enter ${filterType ? (filterType + '...') : 'ingredient...'}`}
         value={newFilter}
         onChangeText={(value) => setNewFilter(value)} />
-        {filterType && 
+      {filterType &&
         <Button buttonStyle={styles.button} onPress={() => newFilter && addFilter(newFilter)}>
           <Icon
             name='plus'
@@ -58,8 +58,8 @@ export function DietaryFilterModal({ filterType, currentFilters, setActiveFilter
             size={22} />
         </Button>}
     </View>
-    <Divider style={{ marginBottom: 10}} />
-    {filterType === 'allergens' ? 
+    <Divider style={{ marginBottom: 10 }} />
+    {filterType === 'allergens' ?
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
         {allergens.concat(currentFilters.filter(f => (f.type === 'allergens') && (!allergens.includes(f.value))).map(f => f.value) ?? []).map(a => (
           <ListItem bottomDivider containerStyle={styles.listItem} key={`${a}-allergens`}>
@@ -69,158 +69,189 @@ export function DietaryFilterModal({ filterType, currentFilters, setActiveFilter
               title={a[0].toUpperCase()}
               containerStyle={{ backgroundColor: "purple" }} />
             <ListItem.Content>
-              <ListItem.Title>{capitaliseFirstLetter(a)}</ListItem.Title>  
+              <ListItem.Title>{capitaliseFirstLetter(a)}</ListItem.Title>
             </ListItem.Content>
             <CheckBox
               key={`${a}-allergens-checkbox`}
               checked={currentFilters
-                ? currentFilters.find(cur => (cur.type === filterType) && (cur.value === formatTextValue(a))) ? true : false 
+                ? currentFilters.find(cur => (cur.type === filterType) && (cur.value === formatTextValue(a))) ? true : false
                 : false}
               onPress={() => onCheckFilter(a)}
               checkedColor="#5A428F"
               uncheckedColor="#BCBCBC"
-              size={22} 
+              checkedIcon={
+                <Icon
+                  name="check-box"
+                  type="material"
+                  color="#5A428F"
+                  size={25}
+                  iconStyle={styles.checkboxIcon}
+                />
+              }
+              size={25}
               containerStyle={styles.checkBoxContainer}
             />
           </ListItem>))}
       </ScrollView>
-      : filterType === 'diets' ? 
-      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
+      : filterType === 'diets' ?
+        <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
           {diets.concat(currentFilters.filter(f => (f.type === 'diets') && (!diets.includes(f.value))).map(f => f.value) ?? []).map(d => (
-          <ListItem bottomDivider containerStyle={styles.listItem} key={`${d}-diets`}>
-            <Avatar
-              size={32}
-              rounded
-              title={d[0].toUpperCase()}
-              containerStyle={{ backgroundColor: "purple" }} />
-            <ListItem.Content>
-              <ListItem.Title>{capitaliseFirstLetter(d)}</ListItem.Title>  
-            </ListItem.Content>
-            <CheckBox
-              key={`${d}-diets-checkbox`}
-              checked={currentFilters
-                ? currentFilters.find(cur => (cur.type === filterType) && (cur.value === formatTextValue(d))) ? true : false 
-                : false}
-              onPress={() => onCheckFilter(d)}
-              containerStyle={styles.checkBoxContainer}
-              checkedColor="#5A428F"
-              uncheckedColor="#BCBCBC"
-              size={22} 
-            />
-          </ListItem>))}
-      </ScrollView>
-      : filterType === 'cuisine' ? 
-      <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
-        {cuisine.concat(currentFilters.filter(f => (f.type === 'cuisine') && (!diets.includes(f.value))).map(f => f.value) ?? []).map(c => (
-          <ListItem bottomDivider containerStyle={styles.listItem} key={`${c}-cuisine`}>
-            <Avatar
-              size={32}
-              rounded
-              title={c[0].toUpperCase()}
-              containerStyle={{ backgroundColor: "purple" }} />
-            <ListItem.Content>
-              <ListItem.Title>{capitaliseFirstLetter(c)}</ListItem.Title>  
-            </ListItem.Content>
-            <CheckBox
-              key={`${c}-cuisine-checkbox`}
-              checked={currentFilters
-                ? currentFilters.find(cur => (cur.type === filterType) && (cur.value === formatTextValue(c))) ? true : false 
-                : false}
-              onPress={() => onCheckFilter(c)}
-              containerStyle={styles.checkBoxContainer}
-              checkedColor="#5A428F"
-              uncheckedColor="#BCBCBC"
-              size={22} 
-            />
-          </ListItem>))}
-      </ScrollView>
-      : <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
-        {(currentFilters?.filter(f => f.type === 'ingredients') ?? []).map(f => 
-          <ListItem bottomDivider containerStyle={styles.listItem} key={`${f.value}-ingredients`}>
-            <Avatar
-              size={32}
-              rounded
-              title={f.value[0].toUpperCase()}
-              containerStyle={{ backgroundColor: "purple" }} />
-            <ListItem.Content>
-              <ListItem.Title>{capitaliseFirstLetter(f.value)}</ListItem.Title>  
-            </ListItem.Content>
-            <Icon
-                name='x'
-                type='feather'
-                iconStyle={styles.badgesCross}
-                size={20}
-                onPress={() => currentFilters.length > 0 
-                  ? setActiveFilters(currentFilters.filter(filter => !(filter === f))) 
-                  : null} />
-          </ListItem>)}
-      </ScrollView>}
+            <ListItem bottomDivider containerStyle={styles.listItem} key={`${d}-diets`}>
+              <Avatar
+                size={32}
+                rounded
+                title={d[0].toUpperCase()}
+                containerStyle={{ backgroundColor: "purple" }} />
+              <ListItem.Content>
+                <ListItem.Title>{capitaliseFirstLetter(d)}</ListItem.Title>
+              </ListItem.Content>
+              <CheckBox
+                key={`${d}-diets-checkbox`}
+                checked={currentFilters
+                  ? currentFilters.find(cur => (cur.type === filterType) && (cur.value === formatTextValue(d))) ? true : false
+                  : false}
+                onPress={() => onCheckFilter(d)}
+                containerStyle={styles.checkBoxContainer}
+                checkedColor="#5A428F"
+                uncheckedColor="#BCBCBC"
+                checkedIcon={
+                  <Icon
+                    name="check-box"
+                    type="material"
+                    color="#5A428F"
+                    size={25}
+                    iconStyle={styles.checkboxIcon}
+                  />
+                }
+                size={25}
+              />
+            </ListItem>))}
+        </ScrollView>
+        : filterType === 'cuisine' ?
+          <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
+            {cuisine.concat(currentFilters.filter(f => (f.type === 'cuisine') && (!diets.includes(f.value))).map(f => f.value) ?? []).map(c => (
+              <ListItem bottomDivider containerStyle={styles.listItem} key={`${c}-cuisine`}>
+                <Avatar
+                  size={32}
+                  rounded
+                  title={c[0].toUpperCase()}
+                  containerStyle={{ backgroundColor: "purple" }} />
+                <ListItem.Content>
+                  <ListItem.Title>{capitaliseFirstLetter(c)}</ListItem.Title>
+                </ListItem.Content>
+                <CheckBox
+                  key={`${c}-cuisine-checkbox`}
+                  checked={currentFilters
+                    ? currentFilters.find(cur => (cur.type === filterType) && (cur.value === formatTextValue(c))) ? true : false
+                    : false}
+                  onPress={() => onCheckFilter(c)}
+                  containerStyle={styles.checkBoxContainer}
+                  checkedColor="#5A428F"
+                  uncheckedColor="#BCBCBC"
+                  checkedIcon={
+                    <Icon
+                      name="check-box"
+                      type="material"
+                      color="#5A428F"
+                      size={25}
+                      iconStyle={styles.checkboxIcon}
+                    />
+                  }
+                  size={25}
+                />
+              </ListItem>))}
+          </ScrollView>
+          : <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
+            {(currentFilters?.filter(f => f.type === 'ingredients') ?? []).map(f =>
+              <ListItem bottomDivider containerStyle={styles.listItem} key={`${f.value}-ingredients`}>
+                <Avatar
+                  size={32}
+                  rounded
+                  title={f.value[0].toUpperCase()}
+                  containerStyle={{ backgroundColor: "purple" }} />
+                <ListItem.Content>
+                  <ListItem.Title>{capitaliseFirstLetter(f.value)}</ListItem.Title>
+                </ListItem.Content>
+                <Icon
+                  name='x'
+                  type='feather'
+                  iconStyle={styles.badgesCross}
+                  size={20}
+                  onPress={() => currentFilters.length > 0
+                    ? setActiveFilters(currentFilters.filter(filter => !(filter === f)))
+                    : null} />
+              </ListItem>)}
+          </ScrollView>}
   </Overlay>
 }
 
 
 const styles = StyleSheet.create({
-    modal: {
-      justifyContent: 'center',
-      alignItems: 'center',
-      backgroundColor: '#FBF8FF',
-      borderRadius: 20,
-      width: '90%',
-      padding: 15,
-    },
-    flexFormGroup: {
-      justifyContent: 'center',
-      alignItems: 'center',
-      width: '100%',
-      padding: 20,
-      paddingBottom: 0,
-      paddingHorizontal: 40,
-      flexDirection: 'row',
-      gap: 15,
-    },
-    title: {
-      fontWeight: '600',
-      fontSize: 22,
-      color: '#281554',
-      paddingVertical: 15,
-    },
-    input: {
-      width: '100%',
-      borderColor: '#CCCCCC',
-      borderWidth: 1,
-      borderRadius: 4,
-      backgroundColor: 'white',
-      paddingHorizontal: 10,
-      fontFamily: 'Roboto',
-      fontSize: 15,
-      color: '#808080',
-      height: 38,                                       
-    },
-    icon: {
-      color:'white',
-    },
-    button: {
-      backgroundColor: '#5A428F',
-      height: 38,
-    },
-    badgesCross: {
-      color: '#BCBCBC',
-    },
-    listItem: {
-      width: '100%',
-      backgroundColor: 'inherit'
-    },
-    scrollView: {
-      maxHeight: 270,
-      width: '100%',
-    },
-    scrollViewContent: {
-      paddingBottom: 10,
-    },
-    checkBoxContainer: {
-      backgroundColor: 'transparent',
-      borderWidth: 0,
-      padding: 0,
-      margin: 0,
-    },
-  });
+  modal: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#FBF8FF',
+    borderRadius: 20,
+    width: '90%',
+    padding: 15,
+  },
+  flexFormGroup: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '100%',
+    padding: 20,
+    paddingBottom: 0,
+    paddingHorizontal: 40,
+    flexDirection: 'row',
+    gap: 15,
+  },
+  title: {
+    fontWeight: '600',
+    fontSize: 22,
+    color: '#281554',
+    paddingVertical: 15,
+  },
+  input: {
+    width: '100%',
+    borderColor: '#CCCCCC',
+    borderWidth: 1,
+    borderRadius: 4,
+    backgroundColor: 'white',
+    paddingHorizontal: 10,
+    fontFamily: 'Roboto',
+    fontSize: 15,
+    color: '#808080',
+    height: 38,
+  },
+  icon: {
+    color: 'white',
+  },
+  checkboxIcon: {
+    marginRight: 3
+  },
+  button: {
+    backgroundColor: '#5A428F',
+    height: 38,
+  },
+  badgesCross: {
+    color: '#BCBCBC',
+  },
+  listItem: {
+    width: '100%',
+    backgroundColor: 'inherit',
+    paddingVertical: 10
+  },
+  scrollView: {
+    maxHeight: 270,
+    width: '100%',
+  },
+  scrollViewContent: {
+    paddingBottom: 10,
+  },
+  checkBoxContainer: {
+    backgroundColor: 'transparent',
+    borderWidth: 0,
+    padding: 0,
+    margin: 0,
+  },
+});

--- a/food-for-thought/components/DietaryFilterModal.tsx
+++ b/food-for-thought/components/DietaryFilterModal.tsx
@@ -4,16 +4,17 @@ import * as React from "react";
 
 export type DietaryFilterProps = {
     setShowModal: React.Dispatch<React.SetStateAction<string | undefined>>,
+    setActiveFilters: React.Dispatch<React.SetStateAction<{ type: string, value: string }[]>>,
+    currentFilters: { type: string, value: string }[],
     filterType: string,
   };
 
-export function DietaryFilterModal({ filterType, setShowModal, ...rest }: DietaryFilterProps) {
-  const [filters, setFilters] = React.useState<{type: string, value: string}[]>();
+export function DietaryFilterModal({ filterType, currentFilters, setActiveFilters, setShowModal, ...rest }: DietaryFilterProps) {
   const [newFilter, setNewFilter] = React.useState<string>();
 
   function addFilter(value: string) {
     if (value === null) return;
-    setFilters(filters ? filters.concat([{ type: filterType, value: value }]) : [{ type: filterType, value: value }]);
+    setActiveFilters(currentFilters ? currentFilters.concat([{ type: filterType, value: value }]) : [{ type: filterType, value: value }])
     setNewFilter(undefined);
     return;
   }
@@ -34,7 +35,7 @@ export function DietaryFilterModal({ filterType, setShowModal, ...rest }: Dietar
       </Button>
     </View>
     <Divider style={{ marginBottom: 10}} />
-    {filters && filters.map(f => <ListItem bottomDivider containerStyle={styles.listItem} key={f.value}>
+    {currentFilters?.map(f => <ListItem bottomDivider containerStyle={styles.listItem} key={f.value}>
       <Avatar
         size={32}
         rounded
@@ -48,7 +49,9 @@ export function DietaryFilterModal({ filterType, setShowModal, ...rest }: Dietar
           type='feather'
           iconStyle={styles.badgesCross}
           size={20}
-          onPress={() => null} />
+          onPress={() => currentFilters.length > 0 
+            ? setActiveFilters(currentFilters.filter(filter => !(filter === f))) 
+            : null} />
     </ListItem>)}
   </Overlay>
 }

--- a/food-for-thought/components/Header.tsx
+++ b/food-for-thought/components/Header.tsx
@@ -14,7 +14,7 @@ export default function Header() {
     return (
         <View style={styles.container}>
             <Card containerStyle={styles.headerCard}>
-                <View style={{ flexDirection: 'row', alignItems: 'flex-start' }}>
+                <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'center' }}>
                     <View style={{ flexDirection: 'row', alignItems: 'center', marginRight: 35, marginTop: 7 }}>
                         <Icon style={{ color: '#000000' }} name='user' type='evilicon' size={35} onPress={() => router.push('/login')}/>
                         <Text style={{ marginLeft: 8 }}>Nep</Text>
@@ -39,6 +39,7 @@ const styles = StyleSheet.create({
     container: {
         flex: 1,
         flexDirection: 'row',
+        maxHeight: 150,
     },
     headerCard: {
         width: width - 32,

--- a/food-for-thought/utils/index.tsx
+++ b/food-for-thought/utils/index.tsx
@@ -1,0 +1,7 @@
+export function capitaliseFirstLetter(string: string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+export function formatTextValue(value: string) {
+    return value.trim().toLowerCase();
+}


### PR DESCRIPTION
Implement filtering for Restaurant Finder.
Users can add and remove dietary filters based on four filter types: `['ingredients', 'diets', 'allergens', 'cuisine']`. 
Refer to the [Figma](https://www.figma.com/design/ffXYx0J3r9AgEw5tyEMxSn/Food-for-Thought?node-id=0-1&t=2a2Sqhgx66XQbA8U-1) for design details. 

<img width="200" alt="image" src="https://github.com/user-attachments/assets/539f291a-61c2-4154-a6e2-b9b0bf5fa93c">
<img width="200" alt="image" src="https://github.com/user-attachments/assets/52452f98-cfa2-4905-8038-f27215f230c0">
<img width="200" alt="image" src="https://github.com/user-attachments/assets/5f73989a-cc7f-4af2-95c1-0e7217d8e85f">

